### PR TITLE
Fix tooltip reaction color

### DIFF
--- a/KkthnxUI/Modules/Tooltip/Tooltip.lua
+++ b/KkthnxUI/Modules/Tooltip/Tooltip.lua
@@ -96,7 +96,7 @@ function Tooltip:GetColor(unit)
 
 		local Hex = K.RGBToHex(unpack(Color))
 
-		return Hex, Color.r, Color.g, Color.b
+		return Hex, Color[1], Color[2], Color[3]
 	end
 end
 


### PR DESCRIPTION
Get the correct reaction color for NPC units, currently returns white because r/g/b doesn't exist for `BETTER_REACTION_COLORS`

I think it only happens for the tooltip's target line, everywhere else appears to be fine.