### PR TITLE
Fix garrison report keybind

### DIFF
--- a/KkthnxUI/Modules/Maps/Minimap.lua
+++ b/KkthnxUI/Modules/Maps/Minimap.lua
@@ -47,6 +47,9 @@ end
 Minimap:SetArchBlobRingScalar(0)
 Minimap:SetQuestBlobRingScalar(0)
 
+-- FIX GARRISON REPORT KEYBIND
+GarrisonLandingPageMinimapButton.IsShown = function() return true end
+
 -- PARENT MINIMAP INTO OUR FRAME
 Minimap:SetParent(MinimapAnchor)
 Minimap:ClearAllPoints()


### PR DESCRIPTION
If the garrison button is hidden on the minimap, the keybind doesn't function.

This makes the BlizzUI think the button is shown, so the keybind will work.