### PR TITLE
Add invert config for minimap

### DIFF
--- a/KkthnxUI/Config/Settings.lua
+++ b/KkthnxUI/Config/Settings.lua
@@ -149,6 +149,7 @@ C["Minimap"] = {
 	["Enable"] = true,
 	["Ping"] = true,
 	["Size"] = 150,
+	["Invert"] = false,
 }
 -- MISCELLANEOUS OPTIONS
 C["Misc"] = {

--- a/KkthnxUI/Modules/Blizzard/Artifact.lua
+++ b/KkthnxUI/Modules/Blizzard/Artifact.lua
@@ -13,8 +13,14 @@ local HasArtifactEquipped = HasArtifactEquipped
 
 local ArtifactAnchor = CreateFrame("Frame", "ArtifactAnchor", UIParent)
 ArtifactAnchor:SetSize(C.Experience.ArtifactWidth, 18)
-ArtifactAnchor:SetPoint("TOPLEFT", Minimap, "BOTTOMLEFT", -1, -33)
-ArtifactAnchor:SetPoint("TOPRIGHT", Minimap, "BOTTOMRIGHT", 1, -33)
+
+if C.Minimap.Invert then
+	ArtifactAnchor:SetPoint("TOPLEFT", Minimap, "TOPLEFT", -1, 53)
+	ArtifactAnchor:SetPoint("TOPRIGHT", Minimap, "BOTTOMRIGHT", 1, 53)
+else
+	ArtifactAnchor:SetPoint("TOPLEFT", Minimap, "BOTTOMLEFT", -1, -33)
+	ArtifactAnchor:SetPoint("TOPRIGHT", Minimap, "BOTTOMRIGHT", 1, -33)
+end
 
 local BarHeight, BarWidth = C.Experience.ArtifactHeight, C.Experience.ArtifactWidth
 local Texture = C.Media.Texture

--- a/KkthnxUI/Modules/Blizzard/Experience.lua
+++ b/KkthnxUI/Modules/Blizzard/Experience.lua
@@ -15,8 +15,14 @@ local color = RAID_CLASS_COLORS[K.Class]
 
 local ExperienceAnchor = CreateFrame("Frame", "ExperienceAnchor", UIParent)
 ExperienceAnchor:SetSize(C.Experience.XPWidth, 18)
-ExperienceAnchor:SetPoint("TOPLEFT", Minimap, "BOTTOMLEFT", -1, -22)
-ExperienceAnchor:SetPoint("TOPRIGHT", Minimap, "BOTTOMRIGHT", 1, -22)
+
+if C.Minimap.Invert then
+	ExperienceAnchor:SetPoint("TOPLEFT", Minimap, "TOPLEFT", -1, 42)
+	ExperienceAnchor:SetPoint("TOPRIGHT", Minimap, "TOPRIGHT", 1, 42)
+else
+	ExperienceAnchor:SetPoint("TOPLEFT", Minimap, "BOTTOMLEFT", -1, -22)
+	ExperienceAnchor:SetPoint("TOPRIGHT", Minimap, "BOTTOMRIGHT", 1, -22)
+end
 
 local FactionInfo = {
 	[1] = {{170/255, 70/255, 70/255}, L_REPUTATION_HATED, "FFaa4646"},

--- a/KkthnxUI/Modules/DataText/Stats.lua
+++ b/KkthnxUI/Modules/DataText/Stats.lua
@@ -17,10 +17,17 @@ if C.Minimap.Enable == true then
 		StatFrame.backdrop:SetBackdropBorderColor(unpack(C.Blizzard.TexturesColor))
 	end
 	StatFrame:SetSize(0, 20)
-	StatFrame:SetPoint("BOTTOMLEFT", Minimap, "BOTTOMLEFT", -2, -24)
+ 
+ 	if C.Minimap.Invert then
+		StatFrame:SetPoint("TOPLEFT", Minimap, "TOPLEFT", -2, 24)
+		StatFrame:SetPoint("TOPRIGHT", Minimap, 2, 24)
+ 	else
+		StatFrame:SetPoint("BOTTOMLEFT", Minimap, "BOTTOMLEFT", -2, -24)
+		StatFrame:SetPoint("BOTTOMRIGHT", Minimap, 2, -24)
+ 	end
+ 	
 	StatFrame:SetFrameLevel(Minimap:GetFrameLevel() + 3)
 	StatFrame:SetFrameStrata(Minimap:GetFrameStrata())
-	StatFrame:SetPoint("BOTTOMRIGHT", Minimap, 2, -24)
 else
 	StatFrame:SetSize(0, 20)
 	StatFrame:SetPoint("BOTTOMLEFT", Minimap, "BOTTOMLEFT", 0, -34)

--- a/KkthnxUI_Config/KkthnxUI_Config.lua
+++ b/KkthnxUI_Config/KkthnxUI_Config.lua
@@ -183,6 +183,7 @@ local function Local(o)
 	if o == "UIConfigMinimapEnable" then o = L_GUI_MINIMAP_ENABLEMINIMAP end
 	if o == "UIConfigMinimapPing" then o = L_GUI_MINIMAP_PING end
 	if o == "UIConfigMinimapSize" then o = L_GUI_MINIMAP_MINIMAPSIZE end
+	if o == "UIConfigMinimapInvert" then o = L_GUI_MINIMAP_MINIMAPINVERT end
 	-- Misc Settings
 	if o == "UIConfigMisc" then o = L_GUI_MISC end
 	if o == "UIConfigMiscAFKCamera" then o = L_GUI_MISC_SPIN_CAMERA end

--- a/KkthnxUI_Config/Locales/enUS.lua
+++ b/KkthnxUI_Config/Locales/enUS.lua
@@ -135,6 +135,7 @@ L_GUI_MINIMAP_COLLECTBUTTONS = "Collect some minimap buttons in one line"
 L_GUI_MINIMAP_ENABLEMINIMAP = "Enable minimap & make it square"
 L_GUI_MINIMAP_MINIMAPSIZE = "Minimap size - Default is 150"
 L_GUI_MINIMAP_PING = "Displays a message when someone pings the minimap. |cffff0000*|r |ccfabd473Kkthnx|r |cffff0000*|r"
+L_GUI_MINIMAP_MINIMAPINVERT = "Move stats and experience bars above minimap"
 -- Misc Localization
 L_GUI_MISC = "Miscellaneous"
 L_GUI_MISC_ALREADY_KNOWN = "Colorizes recipes, mounts & pets that are already known"


### PR DESCRIPTION
I like moving my minimap to the bottom right corner, so I added a config option to move the stats bar and experience/artifact bars above the minimap. it's silly and I definitely understand if you don't want to add it (also could use some renaming probably). just thought I had it on my personal fork I may as well contribute back a little. 

thanks for all the amazing work, seriously. has made legion even more fun for me
