### PR TITLE
Fade objective tracker on mouseover

### DIFF
--- a/KkthnxUI/Config/Settings.lua
+++ b/KkthnxUI/Config/Settings.lua
@@ -61,6 +61,7 @@ C["Blizzard"] = {
 	["Durability"] = true,
 	["MoveAchievements"] = true,
 	["Reputations"] = true,
+	["FadeQuest"] = false,
 }
 -- BUFFS & DEBUFFS OPTIONS
 C["Aura"] = {

--- a/KkthnxUI/Modules/Quests/WatchFrame.lua
+++ b/KkthnxUI/Modules/Quests/WatchFrame.lua
@@ -27,7 +27,20 @@ BONUS_OBJECTIVE_TRACKER_MODULE.Header.Background:Hide()
 ObjectiveTrackerFrame.HeaderMenu.Title:SetAlpha(0)
 OBJECTIVE_TRACKER_DOUBLE_LINE_HEIGHT = 30
 
--- Difficulty color for WatchFrame lines
+-- FADE IN/OUT OBJECTIVE TRACKER ON MOUSEOVER
+if C.Blizzard.FadeQuest then
+	UIFrameFadeOut(ObjectiveTrackerFrame, 0.8, ObjectiveTrackerFrame:GetAlpha(), 0.3)
+
+	ObjectiveTrackerFrame:SetScript("OnEnter", function()
+		ObjectiveTrackerFrame:FadeIn()
+	end)
+
+	ObjectiveTrackerFrame:SetScript("OnLeave", function()
+		UIFrameFadeOut(ObjectiveTrackerFrame, 0.8, ObjectiveTrackerFrame:GetAlpha(), 0.3)
+	end)
+end
+
+-- DIFFICULTY COLOR FOR WATCHFRAME LINES
 hooksecurefunc(QUEST_TRACKER_MODULE, "Update", function()
 	for i = 1, GetNumQuestWatches() do
 		local questID, _, questIndex = GetQuestWatchInfo(i)

--- a/KkthnxUI_Config/KkthnxUI_Config.lua
+++ b/KkthnxUI_Config/KkthnxUI_Config.lua
@@ -104,6 +104,7 @@ local function Local(o)
 	if o == "UIConfigBlizzardDurability" then o = L_GUI_BLIZZARD_DURABILITY end
 	if o == "UIConfigBlizzardMoveAchievements" then o = L_GUI_BLIZZARD_ACHIEVEMENTS end
 	if o == "UIConfigBlizzardReputations" then o = L_GUI_BLIZZARD_REPUTATIONS end
+	if o == "UIConfigBlizzardFadeQuest" then o = L_GUI_BLIZZARD_FADE_QUEST end
 	-- ExpRep Settings
 	if o == "UIConfigExperience" then o = L_GUI_EXPERIENCE end
 	if o == "UIConfigExperienceArtifact" then o = L_GUI_EXPERIENCE_ARTIFACT end

--- a/KkthnxUI_Config/Locales/enUS.lua
+++ b/KkthnxUI_Config/Locales/enUS.lua
@@ -57,6 +57,7 @@ L_GUI_BLIZZARD_COLOR_TEXTURES = "Change most UI texture hue colors."
 L_GUI_BLIZZARD_TEXTURES_COLOR = "UI texture hue color. (Default is Classcolor)"
 L_GUI_BLIZZARD_DURABILITY = "Display the durability % on character slot buttons"
 L_GUI_BLIZZARD_REPUTATIONS = "Display reputation rewards for quests"
+L_GUI_BLIZZARD_FADE_QUEST = "Enable mouseover fade for objective tracker"
 -- ExpRep Localization
 L_GUI_EXPERIENCE = "XPRep & Artifact"
 L_GUI_EXPERIENCE_ARTIFACT = "Enable the Artifact bar."


### PR DESCRIPTION
defaults objective tracker to 0.3 opacity. mouseover fade in/out. i really have no clue what i'm doing