### PR TITLE
Fix databar order

### DIFF
--- a/KkthnxUI/Core/Panels.lua
+++ b/KkthnxUI/Core/Panels.lua
@@ -190,7 +190,7 @@ if C.General.ShowConfigButton == true then
 
 	ToggleButtonSpecial:EnableMouse(true)
 	ToggleButtonSpecial:HookScript("OnMouseDown", function(self, btn)
-		if(InCombatLockdown()) then
+		if(InCombatLockdown() and not btn == "RightButton") then
 			K.Print(ERR_NOT_IN_COMBAT)
 			return
 		end

--- a/KkthnxUI/Modules/DataBars/ArtifactBar.lua
+++ b/KkthnxUI/Modules/DataBars/ArtifactBar.lua
@@ -13,8 +13,12 @@ local Bars = 20
 local Movers = K.Movers
 
 local Anchor = CreateFrame("Frame", "ArtifactAnchor", UIParent)
+local AnchorY = -33
+if K.Level ~= MAX_PLAYER_LEVEL then
+	AnchorY = -48
+end
 Anchor:SetSize(C.DataBars.ArtifactWidth, C.DataBars.ArtifactHeight)
-Anchor:SetPoint("TOP", Minimap, "BOTTOM", 0, -63)
+Anchor:SetPoint("TOP", Minimap, "BOTTOM", 0, AnchorY)
 Movers:RegisterFrame(Anchor)
 
 local ArtifactBar = CreateFrame("StatusBar", nil, UIParent)

--- a/KkthnxUI/Modules/DataBars/HonorBar.lua
+++ b/KkthnxUI/Modules/DataBars/HonorBar.lua
@@ -15,7 +15,7 @@ local Movers = K.Movers
 
 local Anchor = CreateFrame("Frame", "HonorAnchor", UIParent)
 Anchor:SetSize(C.DataBars.HonorWidth, C.DataBars.HonorHeight)
-Anchor:SetPoint("TOP", Minimap, "BOTTOM", 0, -33)
+Anchor:SetPoint("TOP", Minimap, "BOTTOM", 0, -48)
 Movers:RegisterFrame(Anchor)
 
 local HonorBar = CreateFrame("StatusBar", nil, UIParent)

--- a/KkthnxUI/Modules/DataBars/ReputationBar.lua
+++ b/KkthnxUI/Modules/DataBars/ReputationBar.lua
@@ -9,7 +9,7 @@ local Movers = K.Movers
 
 local Anchor = CreateFrame("Frame", "ReputationAnchor", UIParent)
 Anchor:SetSize(C.DataBars.ReputationWidth, C.DataBars.ReputationHeight)
-Anchor:SetPoint("TOP", Minimap, "BOTTOM", 0, -48)
+Anchor:SetPoint("TOP", Minimap, "BOTTOM", 0, -63)
 Movers:RegisterFrame(Anchor)
 
 local ReputationBar = CreateFrame("StatusBar", nil, UIParent)


### PR DESCRIPTION
Data bars on minimap could have a gap if you dont choose a rep to focus, or while leveling. Heres the new order:

- XP bar
- Artifact bar
- Honor bar
- Reputation bar

Also fixes a bug where you couldn't right click the K to show/hide skada and recount while in combat